### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/datadog-synthetics.yml
+++ b/.github/workflows/datadog-synthetics.yml
@@ -21,6 +21,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/abdlelahalwali8-a11y/dr-appointments-hub/security/code-scanning/1](https://github.com/abdlelahalwali8-a11y/dr-appointments-hub/security/code-scanning/1)

To fix this issue, add a `permissions` block specifying the minimum required permissions for this workflow/job. Since the workflow's steps only check out the code and interact with an external service (Datadog), the job most likely only requires `contents: read`. The best practice is to add this at the root or job level—here, adding it at the job level ensures only this job's token has those permissions. Modify the `build` job under `jobs` to insert a `permissions: contents: read` block immediately after the job name. No changes to steps or other workflow functionality are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
