### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,6 @@
 name: Deploy to Vercel
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/abdlelahalwali8-a11y/dr-appointments-hub/security/code-scanning/2](https://github.com/abdlelahalwali8-a11y/dr-appointments-hub/security/code-scanning/2)

To fix the problem, explicitly specify the least privileges required for the `GITHUB_TOKEN` by adding a `permissions` key to the workflow file. The best practice is to set this at the workflow (top) level so that it applies to all jobs, unless some jobs require more granular permissions. Since this workflow is only checking out code and deploying to Vercel (using access tokens/secrets rather than the `GITHUB_TOKEN`), `contents: read` is sufficient. To implement the fix, insert the following block after the `name:` line and before `on:` in `.github/workflows/deploy.yml`:

```yaml
permissions:
  contents: read
```

No imports or additional definitions are needed—just a configuration change at the YAML level.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
