### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,6 @@
 name: Deploy to Hosting
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/abdlelahalwali8-a11y/dr-appointments-hub/security/code-scanning/8](https://github.com/abdlelahalwali8-a11y/dr-appointments-hub/security/code-scanning/8)

To resolve this issue, we should add an explicit `permissions` key to either the root of the workflow file (i.e., as a top-level key, so it applies to all jobs), or directly to the job (`build_and_deploy`). Given that there is only one job and no indications that any step requires write access to the repository, we should set the minimal required permissions (usually `contents: read`). If a step later needs additional permissions (for example, if using a deployment action that creates pull requests or issues), that can be granted explicitly, but the default should be least privilege. 

The change should be made by inserting the following block:
```yaml
permissions:
  contents: read
```
directly below the workflow `name` and before the `on:` block in `.github/workflows/deploy.yml`. No imports or extra code is needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
